### PR TITLE
Display the image from gallery using image_picker

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -43,6 +43,8 @@ PODS:
     - GoogleUtilities/Environment (~> 6.5)
     - GoogleUtilities/UserDefaults (~> 6.5)
   - Flutter (1.0.0)
+  - flutter_plugin_android_lifecycle (0.0.1):
+    - Flutter
   - GoogleAppMeasurement (6.2.2):
     - GoogleUtilities/AppDelegateSwizzler (~> 6.0)
     - GoogleUtilities/MethodSwizzler (~> 6.0)
@@ -71,6 +73,8 @@ PODS:
     - GoogleUtilities/Logger
   - GoogleUtilities/UserDefaults (6.5.1):
     - GoogleUtilities/Logger
+  - image_picker (0.0.1):
+    - Flutter
   - nanopb (0.3.9011):
     - nanopb/decode (= 0.3.9011)
     - nanopb/encode (= 0.3.9011)
@@ -85,6 +89,8 @@ DEPENDENCIES:
   - firebase_analytics (from `.symlinks/plugins/firebase_analytics/ios`)
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
   - Flutter (from `Flutter`)
+  - flutter_plugin_android_lifecycle (from `.symlinks/plugins/flutter_plugin_android_lifecycle/ios`)
+  - image_picker (from `.symlinks/plugins/image_picker/ios`)
   - path_provider (from `.symlinks/plugins/path_provider/ios`)
 
 SPEC REPOS:
@@ -112,6 +118,10 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/firebase_core/ios"
   Flutter:
     :path: Flutter
+  flutter_plugin_android_lifecycle:
+    :path: ".symlinks/plugins/flutter_plugin_android_lifecycle/ios"
+  image_picker:
+    :path: ".symlinks/plugins/image_picker/ios"
   path_provider:
     :path: ".symlinks/plugins/path_provider/ios"
 
@@ -127,10 +137,12 @@ SPEC CHECKSUMS:
   FirebaseInstallations: 575cd32f2aec0feeb0e44f5d0110a09e5e60b47b
   FirebaseInstanceID: 031d7d0c8e7b5c030bbeb4d2a690550375e83fec
   Flutter: 0e3d915762c693b495b44d77113d4970485de6ec
+  flutter_plugin_android_lifecycle: 47de533a02850f070f5696a623995e93eddcdb9b
   GoogleAppMeasurement: d0560d915abf15e692e8538ba1d58442217b6aff
   GoogleDataTransport: 47fe3b8e1673e5187dfd615656a3c5034f150d69
   GoogleDataTransportCCTSupport: 36f69887fd212db6d7ef4dd45ba44523717a434e
   GoogleUtilities: 06eb53bb579efe7099152735900dd04bf09e7275
+  image_picker: e3eacd46b94694dde7cf2705955cece853aa1a8f
   nanopb: 18003b5e52dab79db540fe93fe9579f399bd1ccd
   path_provider: fb74bd0465e96b594bb3b5088ee4a4e7bb1f2a9d
   PromisesObjC: c119f3cd559f50b7ae681fa59dc1acd19173b7e6

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -26,6 +26,8 @@
 	<string>Can I use the camera please?</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Can I use the mic please?</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Can I use the photo library please?</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:flutter_sandbox/routes/index.dart';
 import 'package:flutter_sandbox/widgets/components/drawer.dart';
 import 'package:flutter_sandbox/widgets/screens/assets.dart';
 import 'package:flutter_sandbox/widgets/screens/camera.dart';
+import 'package:flutter_sandbox/widgets/screens/gallery.dart';
 import 'package:flutter_sandbox/widgets/screens/messages.dart';
 import 'package:flutter_sandbox/widgets/screens/profile.dart';
 
@@ -33,6 +34,7 @@ Future<void> main() async {
               // Pass the appropriate camera to the TakePictureScreen widget.
               camera: firstCamera,
             ),
+        Routes.gallery: (BuildContext context) => GalleryScreen(),
         Routes.messages: (BuildContext context) => MessagesScreen(),
         Routes.profile: (BuildContext context) => ProfileScreen(),
       },

--- a/lib/routes/index.dart
+++ b/lib/routes/index.dart
@@ -5,6 +5,7 @@ class Routes {
   static const String home = '/home';
   static const String assets = '/assets';
   static const String camera = '/camera';
+  static const String gallery = '/gallery';
   static const String messages = MessagesScreen.routeName;
   static const String profile = ProfileScreen.routeName;
 }

--- a/lib/widgets/components/drawer.dart
+++ b/lib/widgets/components/drawer.dart
@@ -39,6 +39,12 @@ class AppDrawer extends StatelessWidget {
                 Navigator.of(context).pushReplacementNamed(Routes.camera);
               }),
           ListTile(
+              leading: Icon(Icons.photo),
+              title: Text('Gallery'),
+              onTap: () {
+                Navigator.of(context).pushReplacementNamed(Routes.gallery);
+              }),
+          ListTile(
               leading: Icon(Icons.message),
               title: Text('Messages'),
               onTap: () {

--- a/lib/widgets/screens/gallery.dart
+++ b/lib/widgets/screens/gallery.dart
@@ -1,0 +1,40 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_sandbox/widgets/components/drawer.dart';
+import 'package:image_picker/image_picker.dart';
+
+class GalleryScreen extends StatefulWidget {
+  @override
+  _GalleryScreenState createState() => _GalleryScreenState();
+}
+
+class _GalleryScreenState extends State<GalleryScreen> {
+  File _image;
+
+  Future getImage() async {
+    var image = await ImagePicker.pickImage(source: ImageSource.gallery);
+
+    setState(() {
+      _image = image;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Photo Gallery'),
+      ),
+      body: Center(
+        child: _image == null ? Text('No image selected.') : Image.file(_image),
+      ),
+      drawer: AppDrawer(),
+      floatingActionButton: FloatingActionButton(
+        onPressed: getImage,
+        tooltip: 'Pick Image',
+        child: Icon(Icons.add_photo_alternate),
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -90,6 +90,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.6"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -102,6 +109,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.4"
+  image_picker:
+    dependency: "direct main"
+    description:
+      name: image_picker
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.3+4"
   matcher:
     dependency: transitive
     description:
@@ -228,4 +242,4 @@ packages:
     version: "3.5.0"
 sdks:
   dart: ">=2.4.0 <3.0.0"
-  flutter: ">=1.10.0 <2.0.0"
+  flutter: ">=1.12.13 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   firebase_core: ^0.2.5
   flutter:
     sdk: flutter
+  image_picker: ^0.6.3+4
   path: ^1.6.4
   path_provider: ^1.6.1
 


### PR DESCRIPTION
## Updates

- Install `image_picker` package
    - [image\_picker \| Flutter Package](https://pub.dev/packages/image_picker)
- Add `NSPhotoLibraryUsageDescription` for iOS
    - https://pub.dev/packages/image_picker#ios
    - [NSPhotoLibraryUsageDescription \- Information Property List \| Apple Developer Documentation](https://developer.apple.com/documentation/bundleresources/information_property_list/nsphotolibraryusagedescription)
- Display the image from gallery
    - Refs: https://pub.dev/packages/image_picker#example
    - Using icons:
        - [photo constant \- Icons class \- material library \- Dart API](https://api.flutter.dev/flutter/material/Icons/photo-constant.html)
        - [add\_photo\_alternate constant \- Icons class \- material library \- Dart API](https://api.flutter.dev/flutter/material/Icons/add_photo_alternate-constant.html)

## 📝Tech blog 

- Japanese: [Flutter でデバイスの画像を表示するサンプルコード \| CodeNote](https://codenote.net/mobile-app-framework/4896.html)

## Demo (Android)

### 1. Tap `Gallery` in the drawer.

![2020-03-07 12 42 50](https://user-images.githubusercontent.com/844012/76137424-26b99b80-6080-11ea-9b44-192a48649bfe.jpg)

### 2. Tap `Photo` icon `FloatingActionButton` and select the image from gallery.

![2020-03-07 12 42 56](https://user-images.githubusercontent.com/844012/76137426-2ae5b900-6080-11ea-9aff-cb25c26e209b.jpg)

### 3. Display the selected image from gallery.

![2020-03-07 12 43 15](https://user-images.githubusercontent.com/844012/76137431-2f11d680-6080-11ea-8588-bb971f3ddbd0.jpg)

