### PR TITLE
Display the image from camera app using image_picker

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:flutter_sandbox/routes/index.dart';
 import 'package:flutter_sandbox/widgets/components/drawer.dart';
 import 'package:flutter_sandbox/widgets/screens/assets.dart';
 import 'package:flutter_sandbox/widgets/screens/camera.dart';
+import 'package:flutter_sandbox/widgets/screens/camera_app.dart';
 import 'package:flutter_sandbox/widgets/screens/gallery.dart';
 import 'package:flutter_sandbox/widgets/screens/messages.dart';
 import 'package:flutter_sandbox/widgets/screens/profile.dart';
@@ -34,6 +35,7 @@ Future<void> main() async {
               // Pass the appropriate camera to the TakePictureScreen widget.
               camera: firstCamera,
             ),
+        Routes.cameraApp: (BuildContext context) => CameraAppScreen(),
         Routes.gallery: (BuildContext context) => GalleryScreen(),
         Routes.messages: (BuildContext context) => MessagesScreen(),
         Routes.profile: (BuildContext context) => ProfileScreen(),

--- a/lib/routes/index.dart
+++ b/lib/routes/index.dart
@@ -5,6 +5,7 @@ class Routes {
   static const String home = '/home';
   static const String assets = '/assets';
   static const String camera = '/camera';
+  static const String cameraApp = '/camera_app';
   static const String gallery = '/gallery';
   static const String messages = MessagesScreen.routeName;
   static const String profile = ProfileScreen.routeName;

--- a/lib/widgets/components/drawer.dart
+++ b/lib/widgets/components/drawer.dart
@@ -39,6 +39,12 @@ class AppDrawer extends StatelessWidget {
                 Navigator.of(context).pushReplacementNamed(Routes.camera);
               }),
           ListTile(
+              leading: Icon(Icons.camera_alt),
+              title: Text('Camera App'),
+              onTap: () {
+                Navigator.of(context).pushReplacementNamed(Routes.cameraApp);
+              }),
+          ListTile(
               leading: Icon(Icons.photo),
               title: Text('Gallery'),
               onTap: () {

--- a/lib/widgets/screens/camera_app.dart
+++ b/lib/widgets/screens/camera_app.dart
@@ -1,0 +1,40 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_sandbox/widgets/components/drawer.dart';
+import 'package:image_picker/image_picker.dart';
+
+class CameraAppScreen extends StatefulWidget {
+  @override
+  _CameraAppScreenState createState() => _CameraAppScreenState();
+}
+
+class _CameraAppScreenState extends State<CameraAppScreen> {
+  File _image;
+
+  Future getImage() async {
+    var image = await ImagePicker.pickImage(source: ImageSource.camera);
+
+    setState(() {
+      _image = image;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Camera App'),
+      ),
+      body: Center(
+        child: _image == null ? Text('No image selected.') : Image.file(_image),
+      ),
+      drawer: AppDrawer(),
+      floatingActionButton: FloatingActionButton(
+        onPressed: getImage,
+        tooltip: 'Pick Image',
+        child: Icon(Icons.add_a_photo),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Updates

- Display the image from gallery
    - Refs: [image\_picker \| Flutter Package](https://pub.dev/packages/image_picker)
    - Using icons:
        - [add\_a\_photo constant \- Icons class \- material library \- Dart API](https://api.flutter.dev/flutter/material/Icons/add_a_photo-constant.html)
        - [camera\_alt constant \- Icons class \- material library \- Dart API](https://api.flutter.dev/flutter/material/Icons/camera_alt-constant.html)

## 📝Tech blog 

- [\[Flutter\] カメラアプリで撮影した画像を表示するサンプルコード \| CodeNote](https://codenote.net/mobile-app-framework/4898.html)

## Demo (Android)

### 1. Tap `Camera App` in the drawer.

![2020-03-09 22 35 27](https://user-images.githubusercontent.com/844012/76218465-9fbf1b80-6257-11ea-8046-18ab336ca236.jpg)

### 2. Tap `add_a_photo ` icon `FloatingActionButton` 

![2020-03-09 22 35 33](https://user-images.githubusercontent.com/844012/76218475-a483cf80-6257-11ea-8718-b5fc602c9e26.jpg)

### 3. Take a photo using camera app

![2020-03-09 22 35 41](https://user-images.githubusercontent.com/844012/76218510-b1a0be80-6257-11ea-8bd2-ab9c8b481891.jpg)

### 4. Display the image taken.

![2020-03-09 22 35 53](https://user-images.githubusercontent.com/844012/76218519-b6fe0900-6257-11ea-8d96-1fbdad07666d.jpg)
